### PR TITLE
fix: harden bulk user import against scope abuse and privilege escala…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,18 @@
       <version>3.4.0</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.10.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>3.25.3</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <repositories>
     <repository>

--- a/src/main/java/org/jahia/community/bulkcreateusers/graphql/BulkCreateUsersMutationExtension.java
+++ b/src/main/java/org/jahia/community/bulkcreateusers/graphql/BulkCreateUsersMutationExtension.java
@@ -9,13 +9,19 @@ import org.jahia.community.bulkcreateusers.users.UsersHandler;
 import org.jahia.modules.graphql.provider.dxm.DXGraphQLProvider;
 import org.jahia.modules.graphql.provider.dxm.security.GraphQLRequiresPermission;
 import org.jahia.osgi.BundleUtils;
+import org.jahia.services.content.JCRNodeWrapper;
+import org.jahia.services.content.JCRSessionFactory;
+import org.jahia.services.content.JCRSessionWrapper;
 import org.jahia.settings.SettingsBean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.jcr.PathNotFoundException;
+import javax.jcr.RepositoryException;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
+import java.util.regex.Pattern;
 
 @GraphQLTypeExtension(DXGraphQLProvider.Mutation.class)
 @GraphQLName("BulkCreateUsersMutations")
@@ -23,6 +29,14 @@ import java.util.List;
 public class BulkCreateUsersMutationExtension {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(BulkCreateUsersMutationExtension.class);
+
+    // Permission required to manage users at the server (global) scope.
+    private static final String SERVER_USERS_PERMISSION = "adminUsers";
+    // Permission required to manage users within a single site.
+    private static final String SITE_USERS_PERMISSION = "siteAdminUsers";
+    // A site key is a short, opaque identifier: letters, digits, dash and underscore only. Enforcing this
+    // shape also prevents path traversal when the key is composed into the "/sites/<key>" node path below.
+    private static final Pattern SITE_KEY_PATTERN = Pattern.compile("[A-Za-z0-9_-]{1,150}");
 
     private BulkCreateUsersMutationExtension() {
     }
@@ -50,12 +64,58 @@ public class BulkCreateUsersMutationExtension {
         }
         final String sep = (separator != null && !separator.isEmpty()) ? separator : ",";
         final String site = (siteKey != null && !siteKey.isEmpty()) ? siteKey : null;
+        if (site != null && !isValidSiteKey(site)) {
+            LOGGER.warn("Rejecting bulk user import: malformed siteKey");
+            return new BulkCreateUsersResult(false, 0, 0, 0, 1,
+                    Collections.singletonList("Invalid siteKey"));
+        }
+        // The @GraphQLRequiresPermission gate above is not scope-aware: it does not verify that the caller
+        // may administer the *specific* target. Re-check the permission against the resolved scope so a
+        // caller cannot pivot to a site (or to the global user base) they do not administer.
+        if (!isAuthorizedForScope(site)) {
+            LOGGER.warn("Rejecting bulk user import: caller not authorized for the requested scope");
+            return new BulkCreateUsersResult(false, 0, 0, 0, 1,
+                    Collections.singletonList("Not authorized to manage users in the requested scope"));
+        }
         try {
             return handler.importUsers(csvContent, sep, site, selectedColumns, Boolean.TRUE.equals(overwrite));
         } catch (Exception e) {
             LOGGER.error("Error during bulk user import", e);
             return new BulkCreateUsersResult(false, 0, 0, 0, 1,
                     Collections.singletonList("Internal error during bulk user import"));
+        }
+    }
+
+    /** True when {@code siteKey} is a well-formed, traversal-safe site identifier. Visible for testing. */
+    static boolean isValidSiteKey(String siteKey) {
+        return siteKey != null && SITE_KEY_PATTERN.matcher(siteKey).matches();
+    }
+
+    /**
+     * Verifies the authenticated caller actually holds the users-admin permission on the requested scope,
+     * evaluated through their own (ACL-respecting) session — not the system session used for the writes.
+     *
+     * <ul>
+     *   <li>{@code siteKey == null} (global users): requires {@code adminUsers} on the repository root.</li>
+     *   <li>otherwise: requires {@code siteAdminUsers} (or {@code adminUsers}) on {@code /sites/<siteKey>}.</li>
+     * </ul>
+     *
+     * Fails closed on any repository error or unknown site.
+     */
+    private static boolean isAuthorizedForScope(String siteKey) {
+        try {
+            final JCRSessionWrapper session = JCRSessionFactory.getInstance().getCurrentUserSession();
+            if (siteKey == null) {
+                return session.getNode("/").hasPermission(SERVER_USERS_PERMISSION);
+            }
+            final JCRNodeWrapper siteNode = session.getNode("/sites/" + siteKey);
+            return siteNode.hasPermission(SITE_USERS_PERMISSION) || siteNode.hasPermission(SERVER_USERS_PERMISSION);
+        } catch (PathNotFoundException e) {
+            LOGGER.warn("Authorization denied: requested site does not exist");
+            return false;
+        } catch (RepositoryException e) {
+            LOGGER.error("Authorization check failed; denying import", e);
+            return false;
         }
     }
 }

--- a/src/main/java/org/jahia/community/bulkcreateusers/users/UsersHandler.java
+++ b/src/main/java/org/jahia/community/bulkcreateusers/users/UsersHandler.java
@@ -37,11 +37,28 @@ public class UsersHandler {
     // Matches each [groupName] token in the groups cell
     private static final Pattern GROUP_PATTERN = Pattern.compile("\\[([^\\]]+)\\]");
 
-    // Group names that grant administrative privileges - assignment is refused regardless of the caller's permissions.
-    // Names are compared lower-case against the resolved JCR group name (not the CSV value).
+    // Group names that grant administrative OR platform/site editing privileges - assignment is refused
+    // regardless of the caller's permissions. "privileged" / "site-privileged" are Jahia's built-in groups
+    // that grant author/edit access across the platform or a site, so they are as dangerous to hand out in
+    // bulk as the administrator groups. Names are compared lower-case against the resolved JCR group name
+    // (not the CSV value).
     private static final Set<String> DENIED_GROUPS = new HashSet<>(Arrays.asList(
             "administrators", "server-administrators", "root-administrators",
-            "site-administrators", "system-administrators", "compliance-managers"));
+            "site-administrators", "system-administrators", "compliance-managers",
+            "privileged", "site-privileged"));
+
+    // Server-level group whose members are treated as protected super-users: their accounts are never
+    // overwritten by a bulk import, even when the overwrite flag is set (defends a renamed "root").
+    private static final String SUPER_USER_GROUP = "administrators";
+
+    // Hard ceiling on the number of CSV data rows processed in a single import. Bounds the synchronous,
+    // system-session workload (one createUser + save per row) independently of the byte-size limit.
+    private static final int MAX_ROWS = 100_000;
+
+    // A writable property key must match this shape: a Jahia/JCR-style name, optionally namespaced.
+    // Rejecting anything else stops control characters, whitespace, or path-like tokens from ever
+    // reaching setProperty / createUser as a property name.
+    private static final Pattern SAFE_PROPERTY_NAME = Pattern.compile("[A-Za-z][A-Za-z0-9_]*(:[A-Za-z][A-Za-z0-9_]*)?");
 
     // User-node properties that must never be written from CSV input.
     // Includes role/permission grants, account-lock flips, external-account flags, and the password field
@@ -115,7 +132,14 @@ public class UsersHandler {
 
     private void processRows(CSVReader reader, RowContext ctx, int[] counts) throws IOException {
         String[] row;
+        int rowCount = 0;
         while ((row = reader.readNext()) != null) {
+            if (++rowCount > MAX_ROWS) {
+                LOGGER.warn("Aborting bulk user import: CSV exceeds the maximum of {} data rows", MAX_ROWS);
+                ctx.errors.add("Import aborted: exceeded the maximum of " + MAX_ROWS + " rows");
+                counts[2]++;
+                return;
+            }
             final int result = processUser(row, ctx);
             tally(counts, commitRow(ctx.session, result, ctx.errors));
         }
@@ -166,7 +190,7 @@ public class UsersHandler {
 
     private int handleExistingUser(JCRUserNode existing, Properties props, String groups, RowContext ctx) {
         final boolean canAssignGroups = ctx.layout.groupIdx >= 0;
-        if (ctx.request.overwrite && !"root".equalsIgnoreCase(existing.getName())) {
+        if (ctx.request.overwrite && !isProtectedAccount(existing, ctx.session)) {
             try {
                 for (final Map.Entry<Object, Object> entry : props.entrySet()) {
                     existing.setProperty((String) entry.getKey(), (String) entry.getValue());
@@ -185,6 +209,26 @@ public class UsersHandler {
             addUserToGroups(existing, groups, ctx.request.siteKey, ctx.session);
         }
         return RESULT_SKIPPED;
+    }
+
+    /**
+     * A protected account is never overwritten by a bulk import, even with {@code overwrite=true}.
+     * Covers the built-in {@code root} super-user by name <em>and</em> any member of the server-level
+     * {@code administrators} group, so a renamed super-user is still shielded. On any lookup failure we
+     * fail closed (treat the account as protected) rather than risk overwriting a privileged user.
+     */
+    private boolean isProtectedAccount(JCRUserNode user, JCRSessionWrapper session) {
+        if ("root".equalsIgnoreCase(user.getName())) {
+            return true;
+        }
+        try {
+            final JCRGroupNode admins = groupManagerService.lookupGroup(null, SUPER_USER_GROUP, session);
+            return admins != null && admins.isMember(user);
+        } catch (RuntimeException e) {
+            LOGGER.warn("Treating user {} as protected: membership check failed: {}",
+                    lazy(user.getName()), e.getMessage());
+            return true;
+        }
     }
 
     private int handleNewUser(String username, String password, Properties props, String groups, RowContext ctx) {
@@ -257,14 +301,23 @@ public class UsersHandler {
         return props;
     }
 
-    private static boolean isWritableColumn(String key, Set<String> allowedColumns) {
-        if (key.isEmpty() || "groups".equals(key) || isPropertyDenied(key)) {
+    static boolean isWritableColumn(String key, Set<String> allowedColumns) {
+        if (key.isEmpty() || "groups".equals(key) || !isSafePropertyName(key) || isPropertyDenied(key)) {
             return false;
         }
         return allowedColumns == null || allowedColumns.contains(key);
     }
 
-    private static boolean isPropertyDenied(String key) {
+    /**
+     * True only for a well-formed Jahia/JCR property name (optionally namespaced, e.g. {@code j:firstName}).
+     * Guards against control characters, whitespace, and path-like tokens reaching {@code setProperty}
+     * or {@code createUser} as a property name, complementing the {@link #isPropertyDenied(String)} denylist.
+     */
+    static boolean isSafePropertyName(String key) {
+        return key != null && SAFE_PROPERTY_NAME.matcher(key).matches();
+    }
+
+    static boolean isPropertyDenied(String key) {
         if (DENIED_PROPERTIES.contains(key)) {
             return true;
         }
@@ -297,13 +350,22 @@ public class UsersHandler {
             return;
         }
         // Compare against the resolved JCR name so a CSV alias cannot bypass the denylist.
-        if (DENIED_GROUPS.contains(jahiaGroup.getName().toLowerCase(Locale.ROOT))) {
+        if (isGroupDenied(jahiaGroup.getName())) {
             LOGGER.warn("Refusing to add user {} to privileged group {}",
                     lazy(user.getName()), lazy(jahiaGroup.getName()));
             return;
         }
         jahiaGroup.addMember(user);
         LOGGER.info("Added user {} to group {}", lazy(user.getName()), lazy(jahiaGroup.getName()));
+    }
+
+    /**
+     * True when the resolved JCR group name denotes a privilege-granting group that must never be
+     * assigned via bulk import (administrators and Jahia's built-in privileged/site-privileged groups).
+     * Matching is case-insensitive against the resolved name to defeat CSV alias bypasses.
+     */
+    static boolean isGroupDenied(String resolvedGroupName) {
+        return resolvedGroupName != null && DENIED_GROUPS.contains(resolvedGroupName.toLowerCase(Locale.ROOT));
     }
 
     /**

--- a/src/test/java/org/jahia/community/bulkcreateusers/graphql/BulkCreateUsersMutationExtensionTest.java
+++ b/src/test/java/org/jahia/community/bulkcreateusers/graphql/BulkCreateUsersMutationExtensionTest.java
@@ -1,0 +1,50 @@
+package org.jahia.community.bulkcreateusers.graphql;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link BulkCreateUsersMutationExtension#isValidSiteKey(String)} — the traversal-safe
+ * site-key guard. A malformed key here would be composed into the "/sites/&lt;key&gt;" node path used by
+ * the scope authorization check, so rejecting path tokens is security-relevant.
+ */
+class BulkCreateUsersMutationExtensionTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"digitall", "my-site", "site_01", "ACME", "a"})
+    @DisplayName("accepts well-formed site keys")
+    void acceptsValidKeys(String key) {
+        assertThat(BulkCreateUsersMutationExtension.isValidSiteKey(key)).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "../systemsite", "site/../other", "/sites/x", "a b", "site key", "site!",
+            "../../etc/passwd", "x*", "a:b", "site.key"
+    })
+    @DisplayName("rejects keys containing path, whitespace, or special characters")
+    void rejectsTraversalAndSpecials(String key) {
+        assertThat(BulkCreateUsersMutationExtension.isValidSiteKey(key)).isFalse();
+    }
+
+    @Test
+    @DisplayName("rejects null and empty")
+    void rejectsNullAndEmpty() {
+        assertThat(BulkCreateUsersMutationExtension.isValidSiteKey(null)).isFalse();
+        assertThat(BulkCreateUsersMutationExtension.isValidSiteKey("")).isFalse();
+    }
+
+    @Test
+    @DisplayName("rejects an over-long key")
+    void rejectsOverLongKey() {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 151; i++) {
+            sb.append('a');
+        }
+        assertThat(BulkCreateUsersMutationExtension.isValidSiteKey(sb.toString())).isFalse();
+    }
+}

--- a/src/test/java/org/jahia/community/bulkcreateusers/users/UsersHandlerTest.java
+++ b/src/test/java/org/jahia/community/bulkcreateusers/users/UsersHandlerTest.java
@@ -1,0 +1,145 @@
+package org.jahia.community.bulkcreateusers.users;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for the pure, security-critical decision logic of {@link UsersHandler}:
+ * the property denylist, the property-name safety check, the writable-column gate, and the
+ * privileged-group denylist. These guard a system-session import, so a regression here is a
+ * privilege-escalation regression.
+ */
+class UsersHandlerTest {
+
+    @Nested
+    @DisplayName("isPropertyDenied")
+    class PropertyDenylist {
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "j:password", "j:nodename", "j:accountLocked", "j:external", "j:externalSource",
+                "j:roles", "j:permissions", "jcr:mixinTypes", "jcr:uuid", "j:rolesInGroup", "j:account"
+        })
+        @DisplayName("denies credential, role, lock, external and jcr/internal properties")
+        void deniesDangerousProperties(String key) {
+            assertThat(UsersHandler.isPropertyDenied(key)).isTrue();
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"j:firstName", "j:lastName", "j:email", "j:organization", "preferredLanguage"})
+        @DisplayName("allows benign profile properties")
+        void allowsBenignProperties(String key) {
+            assertThat(UsersHandler.isPropertyDenied(key)).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("isSafePropertyName")
+    class PropertyNameSafety {
+
+        @ParameterizedTest
+        @ValueSource(strings = {"j:firstName", "lastName", "j:email", "preferredLanguage", "x"})
+        @DisplayName("accepts well-formed (optionally namespaced) property names")
+        void acceptsWellFormedNames(String key) {
+            assertThat(UsersHandler.isSafePropertyName(key)).isTrue();
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "j: firstName", "first name", "j:first\nname", "../etc", "j::x", ":x", "1abc", "j:", "a:b:c"
+        })
+        @DisplayName("rejects names with whitespace, control chars, path tokens, or malformed namespaces")
+        void rejectsMalformedNames(String key) {
+            assertThat(UsersHandler.isSafePropertyName(key)).isFalse();
+        }
+
+        @Test
+        @DisplayName("rejects null")
+        void rejectsNull() {
+            assertThat(UsersHandler.isSafePropertyName(null)).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("isWritableColumn")
+    class WritableColumn {
+
+        private final Set<String> allowed = new HashSet<>(java.util.Arrays.asList("j:firstName", "j:email"));
+
+        @Test
+        @DisplayName("writes an allowed, safe, non-denied column")
+        void writesAllowedColumn() {
+            assertThat(UsersHandler.isWritableColumn("j:firstName", allowed)).isTrue();
+        }
+
+        @Test
+        @DisplayName("never writes the reserved groups column")
+        void rejectsGroupsColumn() {
+            assertThat(UsersHandler.isWritableColumn("groups", allowed)).isFalse();
+        }
+
+        @Test
+        @DisplayName("never writes a denied property even if explicitly allowed")
+        void rejectsDeniedEvenWhenAllowed() {
+            Set<String> allowDanger = new HashSet<>(java.util.Arrays.asList("j:password", "j:roles"));
+            assertThat(UsersHandler.isWritableColumn("j:password", allowDanger)).isFalse();
+            assertThat(UsersHandler.isWritableColumn("j:roles", allowDanger)).isFalse();
+        }
+
+        @Test
+        @DisplayName("never writes an unsafe property name even if explicitly allowed")
+        void rejectsUnsafeNameEvenWhenAllowed() {
+            Set<String> allowUnsafe = new HashSet<>(Collections.singletonList("bad name"));
+            assertThat(UsersHandler.isWritableColumn("bad name", allowUnsafe)).isFalse();
+        }
+
+        @Test
+        @DisplayName("does not write a column outside the allowlist")
+        void rejectsColumnOutsideAllowlist() {
+            assertThat(UsersHandler.isWritableColumn("j:lastName", allowed)).isFalse();
+        }
+
+        @Test
+        @DisplayName("null allowlist falls back to import-all (backward compatible)")
+        void nullAllowlistImportsAll() {
+            assertThat(UsersHandler.isWritableColumn("j:lastName", null)).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("isGroupDenied")
+    class GroupDenylist {
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "administrators", "Administrators", "site-administrators", "system-administrators",
+                "compliance-managers", "privileged", "site-privileged", "SITE-PRIVILEGED"
+        })
+        @DisplayName("denies administrator and Jahia privilege-granting groups (case-insensitive)")
+        void deniesPrivilegedGroups(String resolvedName) {
+            assertThat(UsersHandler.isGroupDenied(resolvedName)).isTrue();
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"editors", "marketing", "users", "site-editors"})
+        @DisplayName("allows ordinary groups")
+        void allowsOrdinaryGroups(String resolvedName) {
+            assertThat(UsersHandler.isGroupDenied(resolvedName)).isFalse();
+        }
+
+        @Test
+        @DisplayName("null group name is not denied")
+        void nullGroupNotDenied() {
+            assertThat(UsersHandler.isGroupDenied(null)).isFalse();
+        }
+    }
+}


### PR DESCRIPTION
…tion

Security review SECURITY-746 remediations for the bulk-create-users module, whose import runs under a JCR system session and is therefore guarded only by application-level checks:

- H1: validate siteKey format (traversal-safe) and re-check the caller's users-admin permission against the resolved scope (root for global, /sites/<key> for a site) using their own ACL-respecting session, since @GraphQLRequiresPermission is not scope-aware. Fails closed.
- M1: add Jahia's privilege-granting groups (privileged, site-privileged) to the group denylist so bulk import cannot hand out platform/site edit access.
- M2: cap processed CSV data rows (MAX_ROWS) to bound the synchronous, per-row system-session workload (DoS).
- L1: never overwrite protected accounts on overwrite=true — root by name and any member of the administrators group (shields a renamed super-user).
- L2: reject syntactically unsafe property names before they reach setProperty/createUser, complementing the existing denylist.

Adds JUnit 5 + AssertJ unit tests (67 cases) for the pure decision logic (property denylist/safety, writable-column gate, group denylist, siteKey validation). SonarQube quality gate: OK (0 new security/maintainability/ reliability issues, duplication 0.0%).