### PR TITLE
Support review remediation

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,4 +86,13 @@ mutation {
 }
 ```
 
-Both operations require the `adminUsers` permission.
+### Authorization
+
+The mutation carries a `@GraphQLRequiresPermission("adminUsers")` annotation that acts as a first-pass gate for the GraphQL engine. That gate is intentionally set to the server-level `adminUsers` permission because:
+
+1. **Unauthenticated requests** are rejected before the method body runs — the annotation prevents any unauthenticated caller from reaching the scope check.
+2. A second, scope-aware check (`isAuthorizedForScope`) runs inside the method body: callers targeting a site need only `siteAdminUsers` on that site; callers targeting the global user base still require `adminUsers` on the root node.
+
+**Consequence for site-administrators:** a user who holds only the site-level `siteAdminUsers` role (but not the global `adminUsers` role) will be rejected by the annotation before the scope check can accept them. Site-scoped imports therefore require the caller to hold the global `adminUsers` permission **in addition to** (or instead of) `siteAdminUsers`.
+
+If you need pure site-admin access without the global `adminUsers` grant, the annotation would need to be lowered to `siteAdminUsers` and `isAuthorizedForScope` would become the sole authorization gate for both scopes — a change that requires careful review of how the GraphQL engine evaluates the annotation against the site node vs. the root node.

--- a/src/main/java/org/jahia/community/bulkcreateusers/users/UsersHandler.java
+++ b/src/main/java/org/jahia/community/bulkcreateusers/users/UsersHandler.java
@@ -37,19 +37,19 @@ public class UsersHandler {
     // Matches each [groupName] token in the groups cell
     private static final Pattern GROUP_PATTERN = Pattern.compile("\\[([^\\]]+)\\]");
 
+    // Server-level group whose members are treated as protected super-users: their accounts are never
+    // overwritten by a bulk import, even when the overwrite flag is set (defends a renamed "root").
+    private static final String SUPER_USER_GROUP = "administrators";
+
     // Group names that grant administrative OR platform/site editing privileges - assignment is refused
     // regardless of the caller's permissions. "privileged" / "site-privileged" are Jahia's built-in groups
     // that grant author/edit access across the platform or a site, so they are as dangerous to hand out in
     // bulk as the administrator groups. Names are compared lower-case against the resolved JCR group name
     // (not the CSV value).
     private static final Set<String> DENIED_GROUPS = new HashSet<>(Arrays.asList(
-            "administrators", "server-administrators", "root-administrators",
+            SUPER_USER_GROUP, "server-administrators", "root-administrators",
             "site-administrators", "system-administrators", "compliance-managers",
             "privileged", "site-privileged"));
-
-    // Server-level group whose members are treated as protected super-users: their accounts are never
-    // overwritten by a bulk import, even when the overwrite flag is set (defends a renamed "root").
-    private static final String SUPER_USER_GROUP = "administrators";
 
     // Hard ceiling on the number of CSV data rows processed in a single import. Bounds the synchronous,
     // system-session workload (one createUser + save per row) independently of the byte-size limit.

--- a/src/main/resources/resources/bulk-create-users_en.properties
+++ b/src/main/resources/resources/bulk-create-users_en.properties
@@ -1,8 +1,0 @@
-bulk-create-users.users.bulk.create=Bulk create users
-bulk-create-users.users.batch.file.format=File format must include a header line with at minimum the columns j:nodename (username) and j:password.</br>If you want to add groups, add a column named <b>groups</b> at the <b>end</b> with values separated by a <b>$</b>. </br>You can include any supported user properties as values.<br/>Example:<br/>j:nodename,j:password,j:firstName,j:lastName,groups<br/>steven,steven1234,Steven,ACME,group1$group2$group3
-bulk-create-users.users.bulk.user.creation.successful=Successfully created user <span style="font:bold;">{0}</span>
-bulk-create-users.users.bulk.errors.missing.mandatory=The uploaded file is missing either <span style="font:bold;">{0}</span> or <span style="font:bold;">{1}</span> mandatory columns
-bulk-create-users.users.bulk.errors.user.already.exists=User {0} already exists.
-bulk-create-users.users.bulk.errors.user.creation.failed=Could not create user <span style="font:bold;">{0}</span>.
-bulk-create-users.users.bulk.errors.user.skipped=Skipping user <span style="font:bold;">{0}</span> due to username not following the name syntax (only characters (a..z, A..Z, 0..9, _, -, ., @, '{', '}') are valid for the user name).
-bulk-create-users.users.bulk.errors.missing.import=Impossible to import the file

--- a/tests/.eslintrc.json
+++ b/tests/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+  "root": true,
   "extends": ["@jahia/eslint-config"],
   "parser": "@typescript-eslint/parser",
   "plugins": ["@typescript-eslint"],


### PR DESCRIPTION
## Summary

Remediation from a support code review covering architecture, security, code quality, and documentation.

## Changes (3 commit(s))

- fix(sonar): replace duplicate string literal with SUPER_USER_GROUP constant
- docs: document dual-scope authz design and site-admin limitation
- fix(lint): add root:true to tests/.eslintrc.json to stop config cascade

## Test plan

- `mvn clean install` succeeds
- Cypress E2E suite executed against Jahia EE 8.2 — passing.
