### PR TITLE
fix: harden handler input boundary and result immutability

### DIFF
--- a/src/main/java/org/jahia/community/bulkcreateusers/graphql/BulkCreateUsersResult.java
+++ b/src/main/java/org/jahia/community/bulkcreateusers/graphql/BulkCreateUsersResult.java
@@ -4,6 +4,8 @@ import graphql.annotations.annotationTypes.GraphQLDescription;
 import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 @GraphQLName("BulkCreateUsersResult")
@@ -23,7 +25,9 @@ public class BulkCreateUsersResult {
         this.updatedCount = updatedCount;
         this.skippedCount = skippedCount;
         this.errorCount = errorCount;
-        this.errors = errors;
+        // Defensive copy: the caller's list must not be able to mutate the result after construction.
+        this.errors = (errors == null) ? Collections.emptyList()
+                : Collections.unmodifiableList(new ArrayList<>(errors));
     }
 
     @GraphQLField

--- a/src/main/java/org/jahia/community/bulkcreateusers/users/UsersHandler.java
+++ b/src/main/java/org/jahia/community/bulkcreateusers/users/UsersHandler.java
@@ -72,6 +72,11 @@ public class UsersHandler {
     // Maximum number of characters echoed into a log line for attacker-controlled fields.
     private static final int LOG_FIELD_MAX_LEN = 200;
 
+    // Fallback CSV field separator used when the caller supplies a null/empty one. The handler is a
+    // public OSGi service callable independently of the GraphQL layer, so it must not assume the
+    // separator has already been defaulted/validated upstream.
+    private static final char DEFAULT_SEPARATOR = ',';
+
     private JahiaUserManagerService userManagerService;
     private JahiaGroupManagerService groupManagerService;
 
@@ -107,7 +112,7 @@ public class UsersHandler {
     }
 
     private void runImport(JCRSessionWrapper session, ImportRequest request, int[] counts, List<String> errors) {
-        try (CSVReader reader = new CSVReader(new StringReader(request.csvContent), request.separator.charAt(0), '"')) {
+        try (CSVReader reader = new CSVReader(new StringReader(request.csvContent), separatorChar(request.separator), '"')) {
             final String[] headers = reader.readNext();
             if (headers == null) {
                 LOGGER.error("Missing headers in CSV file");
@@ -128,6 +133,16 @@ public class UsersHandler {
             counts[2]++;
             errors.add("Fatal error: " + e.getMessage());
         }
+    }
+
+    /**
+     * Resolves the single character handed to {@link CSVReader}. A null or empty separator falls back
+     * to {@link #DEFAULT_SEPARATOR}; only the first character is honoured. Prevents a
+     * {@link StringIndexOutOfBoundsException} when the handler is called directly (not via the GraphQL
+     * layer, which defaults the separator itself). Visible for testing.
+     */
+    static char separatorChar(String separator) {
+        return (separator == null || separator.isEmpty()) ? DEFAULT_SEPARATOR : separator.charAt(0);
     }
 
     private void processRows(CSVReader reader, RowContext ctx, int[] counts) throws IOException {
@@ -165,6 +180,12 @@ public class UsersHandler {
         final String username = values.get(layout.userIdx);
         final String password = values.get(layout.passIdx);
         final String groups = (layout.groupIdx >= 0 && layout.groupIdx < values.size()) ? values.get(layout.groupIdx) : null;
+
+        if (username == null || username.trim().isEmpty()) {
+            LOGGER.warn("Skipping row with a blank username");
+            ctx.errors.add("Row skipped: blank username");
+            return RESULT_ERROR;
+        }
 
         final Properties props = buildPropertiesOrReport(values, ctx, username);
         if (props == null) {

--- a/src/test/java/org/jahia/community/bulkcreateusers/graphql/BulkCreateUsersResultTest.java
+++ b/src/test/java/org/jahia/community/bulkcreateusers/graphql/BulkCreateUsersResultTest.java
@@ -1,0 +1,63 @@
+package org.jahia.community.bulkcreateusers.graphql;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link BulkCreateUsersResult}'s defensive handling of the per-row error list:
+ * the result is returned over GraphQL and must not be mutable through the list reference the caller
+ * passed in, nor through the accessor.
+ */
+class BulkCreateUsersResultTest {
+
+    @Test
+    @DisplayName("does not reflect mutations made to the source list after construction")
+    void isolatedFromSourceList() {
+        // Arrange
+        List<String> source = new ArrayList<>(Arrays.asList("row 1 failed"));
+        BulkCreateUsersResult result = new BulkCreateUsersResult(false, 0, 0, 0, 1, source);
+
+        // Act
+        source.add("injected after construction");
+
+        // Assert
+        assertThat(result.getErrors()).containsExactly("row 1 failed");
+    }
+
+    @Test
+    @DisplayName("exposes an unmodifiable error list")
+    void errorsAreUnmodifiable() {
+        BulkCreateUsersResult result = new BulkCreateUsersResult(false, 0, 0, 0, 1,
+                new ArrayList<>(Arrays.asList("boom")));
+
+        assertThatThrownBy(() -> result.getErrors().add("mutate"))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    @DisplayName("treats a null error list as an empty list")
+    void nullErrorsBecomeEmpty() {
+        BulkCreateUsersResult result = new BulkCreateUsersResult(true, 2, 0, 0, 0, null);
+
+        assertThat(result.getErrors()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("preserves the count fields")
+    void preservesCounts() {
+        BulkCreateUsersResult result = new BulkCreateUsersResult(true, 3, 2, 1, 0, null);
+
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.getCreatedCount()).isEqualTo(3);
+        assertThat(result.getUpdatedCount()).isEqualTo(2);
+        assertThat(result.getSkippedCount()).isEqualTo(1);
+        assertThat(result.getErrorCount()).isZero();
+    }
+}

--- a/src/test/java/org/jahia/community/bulkcreateusers/users/UsersHandlerTest.java
+++ b/src/test/java/org/jahia/community/bulkcreateusers/users/UsersHandlerTest.java
@@ -116,6 +116,36 @@ class UsersHandlerTest {
     }
 
     @Nested
+    @DisplayName("separatorChar")
+    class SeparatorResolution {
+
+        @Test
+        @DisplayName("falls back to comma for a null separator")
+        void nullFallsBackToComma() {
+            assertThat(UsersHandler.separatorChar(null)).isEqualTo(',');
+        }
+
+        @Test
+        @DisplayName("falls back to comma for an empty separator")
+        void emptyFallsBackToComma() {
+            assertThat(UsersHandler.separatorChar("")).isEqualTo(',');
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {";", "\t", "|", ","})
+        @DisplayName("honours the first character of a non-empty separator")
+        void honoursFirstCharacter(String separator) {
+            assertThat(UsersHandler.separatorChar(separator)).isEqualTo(separator.charAt(0));
+        }
+
+        @Test
+        @DisplayName("uses only the first character of a multi-character separator")
+        void usesOnlyFirstCharacter() {
+            assertThat(UsersHandler.separatorChar(";;")).isEqualTo(';');
+        }
+    }
+
+    @Nested
     @DisplayName("isGroupDenied")
     class GroupDenylist {
 


### PR DESCRIPTION
## Summary

Behavior-preserving defense-in-depth on `bulk-create-users`. The module was already substantially hardened on `main` (row bounds, try-with-resources, per-row error isolation, log sanitization, password safety, scope-aware admin gating). This PR closes three remaining genuine gaps found at the trust boundaries.

## Changes

- **S1/R1 — `UsersHandler` separator validation** (`UsersHandler.java`): `runImport` did `request.separator.charAt(0)` directly. `UsersHandler` is a public `@Component` OSGi service callable independently of the GraphQL layer (which is the only thing defaulting an empty separator to `,`). A direct caller passing `""` or `null` threw `StringIndexOutOfBoundsException`/NPE. Added `separatorChar(String)` that falls back to a `DEFAULT_SEPARATOR` constant.
- **S2/R2 — blank-username row isolation** (`UsersHandler.java`): a null/blank CSV username cell flowed into `lookupUser`/`isUsernameSyntaxCorrect`/`createUser`. Now reported as a per-row error and isolated (`RESULT_ERROR`) instead of propagating null.
- **S3/R3 — result immutability** (`BulkCreateUsersResult.java`): the constructor stored the caller's list and `getErrors()` exposed it directly. Now a defensive copy wrapped in `unmodifiableList`; a null list becomes empty.

## Tests

+11 unit tests (JUnit 5 + AssertJ, matching the repo):
- `UsersHandlerTest.SeparatorResolution` — null/empty fallback, first-char honoured, multi-char truncation (7).
- `BulkCreateUsersResultTest` — source-list isolation, unmodifiable accessor, null→empty, count preservation (4).

## Build

`mvn -o clean install` — BUILD SUCCESS, 78 tests pass (was 67). No pom/Java-version/dependency changes.