### PR TITLE
feat: replace adminUsers with module-specific adminUsersBulkCreate permission

### DIFF
--- a/src/javascript/registrations/users/registerRoutes.js
+++ b/src/javascript/registrations/users/registerRoutes.js
@@ -6,7 +6,7 @@ import CreateUsers from '../CreateUsers';
 export const registerRoutes = function () {
     registry.add('adminRoute', 'bulkCreateUsers', {
         targets: ['administration-server-usersAndRoles:999'],
-        requiredPermission: 'adminUsers',
+        requiredPermission: 'adminUsersBulkCreate',
         icon: null,
         label: 'bulk-create-users:users.label',
         isSelectable: true,

--- a/src/main/import/permissions.xml
+++ b/src/main/import/permissions.xml
@@ -1,2 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<permissions xmlns:jcr="http://www.jcp.org/jcr/1.0" />
+<permissions xmlns:jcr="http://www.jcp.org/jcr/1.0">
+    <admin jcr:primaryType="jnt:permission">
+        <adminUsersBulkCreate jcr:primaryType="jnt:permission"/>
+    </admin>
+</permissions>

--- a/src/main/java/org/jahia/community/bulkcreateusers/graphql/BulkCreateUsersMutationExtension.java
+++ b/src/main/java/org/jahia/community/bulkcreateusers/graphql/BulkCreateUsersMutationExtension.java
@@ -44,7 +44,7 @@ public class BulkCreateUsersMutationExtension {
     @GraphQLField
     @GraphQLName("bulkCreateUsersImport")
     @GraphQLDescription("Imports users from a CSV string; returns a detailed result with per-user counts and errors")
-    @GraphQLRequiresPermission("adminUsers")
+    @GraphQLRequiresPermission("adminUsersBulkCreate")
     public static BulkCreateUsersResult importUsers(
             @GraphQLName("csvContent") @GraphQLNonNull final String csvContent,
             @GraphQLName("separator") final String separator,

--- a/src/main/java/org/jahia/community/bulkcreateusers/graphql/BulkCreateUsersQueryExtension.java
+++ b/src/main/java/org/jahia/community/bulkcreateusers/graphql/BulkCreateUsersQueryExtension.java
@@ -19,7 +19,7 @@ public class BulkCreateUsersQueryExtension {
     @GraphQLField
     @GraphQLName("bulkCreateUsersMaxUploadSize")
     @GraphQLDescription("Maximum allowed CSV upload size in bytes, as configured in Jahia settings")
-    @GraphQLRequiresPermission("adminUsers")
+    @GraphQLRequiresPermission("adminUsersBulkCreate")
     public static Long maxUploadSize() {
         return SettingsBean.getInstance().getJahiaFileUploadMaxSize();
     }


### PR DESCRIPTION
## Summary

- Introduces `admin/adminUsersBulkCreate` as a module-scoped `jnt:permission` node in `src/main/import/permissions.xml` (child of `admin`), replacing the reliance on the global `adminUsers` permission.
- Updates `@GraphQLRequiresPermission` on `BulkCreateUsersMutationExtension#importUsers` from `"adminUsers"` to `"adminUsersBulkCreate"`.
- Updates `@GraphQLRequiresPermission` on `BulkCreateUsersQueryExtension#maxUploadSize` from `"adminUsers"` to `"adminUsersBulkCreate"`.
- No changes to Java logic, tests, or pom.xml.

## Test plan

- [ ] `mvn -q clean install` passes locally (verified green).
- [ ] On a running Jahia instance: grant `adminUsersBulkCreate` to a test user and confirm the `bulkCreateUsersImport` mutation and `bulkCreateUsersMaxUploadSize` query succeed.
- [ ] Confirm a user with only `adminUsers` (but not `adminUsersBulkCreate`) is denied by the GraphQL gate.
- [ ] Confirm the permission node is visible in the Jahia permission tree under `admin`.