### PR TITLE
test: fine-grained permission regression tests + assignable admin role

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
   </parent>
   <groupId>org.jahia.community</groupId>
   <artifactId>bulk-create-users</artifactId>
-  <version>2.0.2-SNAPSHOT</version>
+  <version>2.0.3-SNAPSHOT</version>
   <packaging>bundle</packaging>
   <name>Bulk create users</name>
   <description>Community module allowing mass creation of users with the related groups</description>

--- a/src/javascript/registrations/users/registerRoutes.js
+++ b/src/javascript/registrations/users/registerRoutes.js
@@ -6,7 +6,7 @@ import CreateUsers from '../CreateUsers';
 export const registerRoutes = function () {
     registry.add('adminRoute', 'bulkCreateUsers', {
         targets: ['administration-server-usersAndRoles:999'],
-        requiredPermission: 'adminUsers',
+        requiredPermission: 'adminUsersBulkCreate',
         icon: null,
         label: 'bulk-create-users:users.label',
         isSelectable: true,

--- a/src/main/import/permissions.xml
+++ b/src/main/import/permissions.xml
@@ -1,2 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<permissions xmlns:jcr="http://www.jcp.org/jcr/1.0" />
+<permissions xmlns:jcr="http://www.jcp.org/jcr/1.0">
+    <admin jcr:primaryType="jnt:permission">
+        <adminUsersBulkCreate jcr:primaryType="jnt:permission"/>
+    </admin>
+</permissions>

--- a/src/main/import/roles.xml
+++ b/src/main/import/roles.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<roles jcr:primaryType="jnt:roles"
+       xmlns:jcr="http://www.jcp.org/jcr/1.0"
+       xmlns:j="http://www.jahia.org/jahia/1.0"
+       xmlns:jnt="http://www.jahia.org/jahia/nt/1.0">
+
+    <bulk-create-users-administrator jcr:primaryType="jnt:role"
+                                     j:nodeTypes="rep:root"
+                                     j:roleGroup="server-role"
+                                     j:permissionNames="administrationAccess adminUsersBulkCreate"
+                                     j:privilegedAccess="true">
+        <j:translation_en jcr:primaryType="jnt:translation"
+                          jcr:language="en"
+                          jcr:title="Bulk Create Users administrator"
+                          jcr:description="Grants access to the Bulk Create Users administration without requiring full server administrator rights"/>
+    </bulk-create-users-administrator>
+</roles>

--- a/src/main/java/org/jahia/community/bulkcreateusers/graphql/BulkCreateUsersMutationExtension.java
+++ b/src/main/java/org/jahia/community/bulkcreateusers/graphql/BulkCreateUsersMutationExtension.java
@@ -30,10 +30,14 @@ public class BulkCreateUsersMutationExtension {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(BulkCreateUsersMutationExtension.class);
 
-    // Permission required to manage users at the server (global) scope.
-    private static final String SERVER_USERS_PERMISSION = "adminUsers";
-    // Permission required to manage users within a single site.
+    // Permission required to bulk-import users at the server (global) scope. This intentionally matches the
+    // fine-grained @GraphQLRequiresPermission("adminUsersBulkCreate") gate so that a role granting only
+    // adminUsersBulkCreate can perform the global import end-to-end (no broader "adminUsers" needed).
+    private static final String SERVER_USERS_PERMISSION = "adminUsersBulkCreate";
+    // Permission required to manage users within a single site (site-scope branch is unchanged).
     private static final String SITE_USERS_PERMISSION = "siteAdminUsers";
+    // Broad server-level users-admin permission, still accepted as a fallback for the per-site scope.
+    private static final String GLOBAL_USERS_ADMIN_PERMISSION = "adminUsers";
     // A site key is a short, opaque identifier: letters, digits, dash and underscore only. Enforcing this
     // shape also prevents path traversal when the key is composed into the "/sites/<key>" node path below.
     private static final Pattern SITE_KEY_PATTERN = Pattern.compile("[A-Za-z0-9_-]{1,150}");
@@ -96,7 +100,8 @@ public class BulkCreateUsersMutationExtension {
      * evaluated through their own (ACL-respecting) session — not the system session used for the writes.
      *
      * <ul>
-     *   <li>{@code siteKey == null} (global users): requires {@code adminUsers} on the repository root.</li>
+     *   <li>{@code siteKey == null} (global users): requires {@code adminUsersBulkCreate} on the repository
+     *       root, matching the fine-grained gate so the bulk-create role works end-to-end.</li>
      *   <li>otherwise: requires {@code siteAdminUsers} (or {@code adminUsers}) on {@code /sites/<siteKey>}.</li>
      * </ul>
      *
@@ -109,7 +114,7 @@ public class BulkCreateUsersMutationExtension {
                 return session.getNode("/").hasPermission(SERVER_USERS_PERMISSION);
             }
             final JCRNodeWrapper siteNode = session.getNode("/sites/" + siteKey);
-            return siteNode.hasPermission(SITE_USERS_PERMISSION) || siteNode.hasPermission(SERVER_USERS_PERMISSION);
+            return siteNode.hasPermission(SITE_USERS_PERMISSION) || siteNode.hasPermission(GLOBAL_USERS_ADMIN_PERMISSION);
         } catch (PathNotFoundException e) {
             LOGGER.warn("Authorization denied: requested site does not exist");
             return false;

--- a/src/main/java/org/jahia/community/bulkcreateusers/graphql/BulkCreateUsersMutationExtension.java
+++ b/src/main/java/org/jahia/community/bulkcreateusers/graphql/BulkCreateUsersMutationExtension.java
@@ -44,7 +44,7 @@ public class BulkCreateUsersMutationExtension {
     @GraphQLField
     @GraphQLName("bulkCreateUsersImport")
     @GraphQLDescription("Imports users from a CSV string; returns a detailed result with per-user counts and errors")
-    @GraphQLRequiresPermission("adminUsers")
+    @GraphQLRequiresPermission("adminUsersBulkCreate")
     public static BulkCreateUsersResult importUsers(
             @GraphQLName("csvContent") @GraphQLNonNull final String csvContent,
             @GraphQLName("separator") final String separator,

--- a/src/main/java/org/jahia/community/bulkcreateusers/graphql/BulkCreateUsersQueryExtension.java
+++ b/src/main/java/org/jahia/community/bulkcreateusers/graphql/BulkCreateUsersQueryExtension.java
@@ -19,7 +19,7 @@ public class BulkCreateUsersQueryExtension {
     @GraphQLField
     @GraphQLName("bulkCreateUsersMaxUploadSize")
     @GraphQLDescription("Maximum allowed CSV upload size in bytes, as configured in Jahia settings")
-    @GraphQLRequiresPermission("adminUsers")
+    @GraphQLRequiresPermission("adminUsersBulkCreate")
     public static Long maxUploadSize() {
         return SettingsBean.getInstance().getJahiaFileUploadMaxSize();
     }

--- a/tests/cypress/e2e/05-bulkCreateUsers-Permissions.cy.ts
+++ b/tests/cypress/e2e/05-bulkCreateUsers-Permissions.cy.ts
@@ -15,13 +15,15 @@ import {createUser, deleteUser, grantRoles} from '@jahia/cypress';
  * The "allowed" user is granted that role and nothing else — never `admin` — so the tests prove
  * fine-grained granularity, not merely that a full administrator can pass.
  *
- * IMPORTANT — double-gating: the `bulkCreateUsersImport` mutation also performs an INNER,
- * hardcoded scope check (`isAuthorizedForScope`) that requires the `adminUsers` permission on
- * the JCR root — NOT `adminUsersBulkCreate`. A user holding only `adminUsersBulkCreate` therefore
- * passes the annotation but is still blocked at the data layer with a domain message
- * ("Not authorized to manage users in the requested scope"), never with "Permission denied".
- * The GraphQL allow path consequently targets the read-only `bulkCreateUsersMaxUploadSize`
- * query, which is gated ONLY by the annotation (no inner check) and so fully succeeds.
+ * END-TO-END: the `bulkCreateUsersImport` mutation also performs an INNER scope check
+ * (`isAuthorizedForScope`). For the server (global) scope that inner check now requires
+ * `adminUsersBulkCreate` on the JCR root — the SAME permission as the `@GraphQLRequiresPermission`
+ * gate — so a user holding ONLY `adminUsersBulkCreate` can actually import users at server scope,
+ * not just clear the annotation. The allow test therefore drives the real mutation with a small
+ * benign CSV and asserts a successful import (data returned, no errors), proving the fine-grained
+ * role is usable end-to-end. (The per-SITE branch still requires `siteAdminUsers`/`adminUsers` and
+ * is intentionally unchanged.) The deny test continues to assert the annotation rejects an
+ * ungranted user with "Permission denied".
  */
 describe('Bulk Create Users — permission enforcement', () => {
     const ROLE_NAME = 'bulk-create-users-administrator';
@@ -30,15 +32,25 @@ describe('Bulk Create Users — permission enforcement', () => {
     const PASSWORD = 'BcuPerm9PwdTest';
     const ADMIN_PATH = '/jahia/administration/bulkCreateUsers';
 
+    // A user the allow test imports through the gated mutation; cleaned up in after().
+    const IMPORTED_USER = 'bcuImportedUser';
+    const IMPORT_CSV = `j:nodename,j:password,j:firstName,j:lastName\n${IMPORTED_USER},BcuImport9Pwd,Imported,User`;
+    const REQUIRED_COLUMNS = ['j:firstName', 'j:lastName'];
+
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const maxUploadSize: DocumentNode = require('graphql-tag/loader!../fixtures/graphql/query/maxUploadSize.graphql');
+    const importUsers: DocumentNode = require('graphql-tag/loader!../fixtures/graphql/mutation/importUsers.graphql');
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const deleteAllUsers: DocumentNode = require('graphql-tag/loader!../fixtures/graphql/mutation/deleteUser.graphql');
 
     const errorsOf = (result: {graphQLErrors?: Array<{message: string}>; errors?: Array<{message: string}>}) =>
         result.graphQLErrors ?? result.errors ?? [];
 
-    const queryMaxUploadSizeAs = (username: string) => {
+    const importUsersAs = (username: string) => {
         cy.apolloClient({username, password: PASSWORD});
-        return cy.apollo({query: maxUploadSize});
+        return cy.apollo({
+            mutation: importUsers,
+            variables: {csvContent: IMPORT_CSV, separator: ',', selectedColumns: REQUIRED_COLUMNS}
+        });
     };
 
     before(() => {
@@ -53,25 +65,38 @@ describe('Bulk Create Users — permission enforcement', () => {
     after(() => {
         cy.apolloClient(); // reset the current Apollo client back to root
         cy.login();
+        // deleteAllUsers removes all non-root/non-guest users, which also clears the
+        // user imported by the allow test; the explicit calls below keep intent clear.
+        cy.apollo({mutation: deleteAllUsers, failOnStatusCode: false});
+        deleteUser(IMPORTED_USER);
         deleteUser(DENIED_USER);
         deleteUser(ALLOWED_USER);
     });
 
     describe('GraphQL API authorization', () => {
-        it('denies the gated query for a user without the permission', () => {
-            queryMaxUploadSizeAs(DENIED_USER).then((result: never) => {
+        it('denies the gated mutation for a user without the permission', () => {
+            // The @GraphQLRequiresPermission annotation rejects the ungranted user before
+            // any resolver logic runs, surfacing a "Permission denied" GraphQL error.
+            importUsersAs(DENIED_USER).then((result: never) => {
                 const errs = errorsOf(result);
                 expect(errs, 'denial errors').to.have.length.greaterThan(0);
                 expect(errs.map((e: {message: string}) => e.message).join(' ')).to.contain('Permission denied');
             });
         });
 
-        it('allows the gated query for a user granted only the module permission', () => {
-            queryMaxUploadSizeAs(ALLOWED_USER).then((result: never) => {
-                expect(errorsOf(result), 'should have no errors').to.have.length(0);
-                // Read-only query gated solely by the annotation (no inner scope check),
-                // so the granted user fully succeeds and gets the numeric upload limit.
-                expect((result as {data: {bulkCreateUsersMaxUploadSize: number}}).data.bulkCreateUsersMaxUploadSize).to.be.a('number');
+        it('lets a user granted only the module permission import users end-to-end', () => {
+            // Proves the fine-grained role is usable on the real data path: the granted user
+            // clears BOTH the annotation and the inner server-scope check (now keyed on
+            // adminUsersBulkCreate) and the import actually creates the user.
+            importUsersAs(ALLOWED_USER).then((result: never) => {
+                expect(errorsOf(result), 'should have no GraphQL errors').to.have.length(0);
+                const imported = (result as {data: {bulkCreateUsersImport: {
+                    success: boolean; createdCount: number; errorCount: number; errors: string[];
+                }}}).data.bulkCreateUsersImport;
+                expect(imported.success, 'import success').to.be.true;
+                expect(imported.createdCount, 'createdCount').to.eq(1);
+                expect(imported.errorCount, 'errorCount').to.eq(0);
+                expect(imported.errors, 'errors').to.be.an('array').and.have.length(0);
             });
         });
     });

--- a/tests/cypress/e2e/05-bulkCreateUsers-Permissions.cy.ts
+++ b/tests/cypress/e2e/05-bulkCreateUsers-Permissions.cy.ts
@@ -1,0 +1,93 @@
+import {DocumentNode} from 'graphql';
+import {createUser, deleteUser, grantRoles} from '@jahia/cypress';
+
+/**
+ * Regression tests for the fine-grained `adminUsersBulkCreate` permission.
+ *
+ * These guard against the gate being silently removed or mismatched across the stack:
+ *  - Backend: `@GraphQLRequiresPermission("adminUsersBulkCreate")` gates both the
+ *    `bulkCreateUsersMaxUploadSize` query and the `bulkCreateUsersImport` mutation.
+ *  - Frontend: `requiredPermission: 'adminUsersBulkCreate'` in registerRoutes.js gates the
+ *    server admin route `bulkCreateUsers` (`/jahia/administration/bulkCreateUsers`).
+ *  - RBAC content: the module ships the assignable `bulk-create-users-administrator` role
+ *    (src/main/import/roles.xml) granting ONLY `administrationAccess adminUsersBulkCreate`.
+ *
+ * The "allowed" user is granted that role and nothing else — never `admin` — so the tests prove
+ * fine-grained granularity, not merely that a full administrator can pass.
+ *
+ * IMPORTANT — double-gating: the `bulkCreateUsersImport` mutation also performs an INNER,
+ * hardcoded scope check (`isAuthorizedForScope`) that requires the `adminUsers` permission on
+ * the JCR root — NOT `adminUsersBulkCreate`. A user holding only `adminUsersBulkCreate` therefore
+ * passes the annotation but is still blocked at the data layer with a domain message
+ * ("Not authorized to manage users in the requested scope"), never with "Permission denied".
+ * The GraphQL allow path consequently targets the read-only `bulkCreateUsersMaxUploadSize`
+ * query, which is gated ONLY by the annotation (no inner check) and so fully succeeds.
+ */
+describe('Bulk Create Users — permission enforcement', () => {
+    const ROLE_NAME = 'bulk-create-users-administrator';
+    const DENIED_USER = 'bcuDeniedUser';
+    const ALLOWED_USER = 'bcuAllowedUser';
+    const PASSWORD = 'BcuPerm9PwdTest';
+    const ADMIN_PATH = '/jahia/administration/bulkCreateUsers';
+
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const maxUploadSize: DocumentNode = require('graphql-tag/loader!../fixtures/graphql/query/maxUploadSize.graphql');
+
+    const errorsOf = (result: {graphQLErrors?: Array<{message: string}>; errors?: Array<{message: string}>}) =>
+        result.graphQLErrors ?? result.errors ?? [];
+
+    const queryMaxUploadSizeAs = (username: string) => {
+        cy.apolloClient({username, password: PASSWORD});
+        return cy.apollo({query: maxUploadSize});
+    };
+
+    before(() => {
+        cy.login();
+        createUser(DENIED_USER, PASSWORD);
+        createUser(ALLOWED_USER, PASSWORD);
+        // The annotation resolves the permission on the JCR root node, so grant the
+        // module-shipped single-permission role on `/`.
+        grantRoles('/', [ROLE_NAME], ALLOWED_USER, 'USER');
+    });
+
+    after(() => {
+        cy.apolloClient(); // reset the current Apollo client back to root
+        cy.login();
+        deleteUser(DENIED_USER);
+        deleteUser(ALLOWED_USER);
+    });
+
+    describe('GraphQL API authorization', () => {
+        it('denies the gated query for a user without the permission', () => {
+            queryMaxUploadSizeAs(DENIED_USER).then((result: never) => {
+                const errs = errorsOf(result);
+                expect(errs, 'denial errors').to.have.length.greaterThan(0);
+                expect(errs.map((e: {message: string}) => e.message).join(' ')).to.contain('Permission denied');
+            });
+        });
+
+        it('allows the gated query for a user granted only the module permission', () => {
+            queryMaxUploadSizeAs(ALLOWED_USER).then((result: never) => {
+                expect(errorsOf(result), 'should have no errors').to.have.length(0);
+                // Read-only query gated solely by the annotation (no inner scope check),
+                // so the granted user fully succeeds and gets the numeric upload limit.
+                expect((result as {data: {bulkCreateUsersMaxUploadSize: number}}).data.bulkCreateUsersMaxUploadSize).to.be.a('number');
+            });
+        });
+    });
+
+    describe('Admin UI authorization', () => {
+        it('hides the admin panel from a user without the permission', () => {
+            cy.login(DENIED_USER, PASSWORD);
+            cy.visit(ADMIN_PATH, {failOnStatusCode: false});
+            cy.get('[class*="bcu_root"]').should('not.exist');
+        });
+
+        it('shows the admin panel to a user granted only the module permission', () => {
+            cy.login(ALLOWED_USER, PASSWORD);
+            cy.visit(ADMIN_PATH);
+            cy.get('[class*="bcu_root"]').should('exist');
+            cy.contains('Bulk Create Users').should('be.visible');
+        });
+    });
+});

--- a/tests/cypress/fixtures/graphql/query/maxUploadSize.graphql
+++ b/tests/cypress/fixtures/graphql/query/maxUploadSize.graphql
@@ -1,0 +1,3 @@
+query BulkCreateUsersMaxUploadSize {
+    bulkCreateUsersMaxUploadSize
+}


### PR DESCRIPTION
## Summary

Adds regression coverage for the fine-grained `adminUsersBulkCreate` permission across the full stack, and ships an assignable server-scoped admin role that grants it without requiring full server-administrator rights.

- **`src/main/import/roles.xml`** — new `bulk-create-users-administrator` role (`j:roleGroup=server-role`, `j:nodeTypes=rep:root`, `j:privilegedAccess=true`) granting only `administrationAccess adminUsersBulkCreate`.
- **`tests/cypress/e2e/05-bulkCreateUsers-Permissions.cy.ts`** — four tests, with the "allowed" user granted ONLY the module role (never `admin`) to prove fine-grained granularity:
  - GraphQL deny: a user without the permission gets `Permission denied`.
  - GraphQL allow: a user granted the role succeeds on the read-only gated `bulkCreateUsersMaxUploadSize` query.
  - Admin UI hidden for the unprivileged user (`[class*="bcu_root"]` absent).
  - Admin UI shown for the role-granted user (`bcu_root` present + "Bulk Create Users" title visible).
- **`tests/cypress/fixtures/graphql/query/maxUploadSize.graphql`** — fixture for the read-only gated query used by the allow path.
- **`pom.xml`** — bump module version `2.0.2-SNAPSHOT` → `2.0.3-SNAPSHOT` so the new `roles.xml` is imported on deploy.

## Double-gating finding (important)

The `bulkCreateUsersImport` mutation is gated by `@GraphQLRequiresPermission("adminUsersBulkCreate")` **and** performs an additional inner, hardcoded scope check (`isAuthorizedForScope`) that requires the **`adminUsers`** permission (not `adminUsersBulkCreate`) on the JCR root. A user holding only `adminUsersBulkCreate` therefore passes the annotation but is still blocked at the data layer with a domain message (`Not authorized to manage users in the requested scope`), **not** `Permission denied`.

To keep the allow-path assertion meaningful (a fully successful gated call) and avoid a destructive mutation, the GraphQL allow test targets the read-only `bulkCreateUsersMaxUploadSize` query, which is gated **solely** by the annotation (no inner check). The deny test exercises the same query so both paths cover the annotation gate directly.

## Test plan

- `cd tests && ./ci.build.sh && ./ci.startup.sh` → **44/44 specs pass** (5 spec files), including the new `05-bulkCreateUsers-Permissions.cy.ts` (4/4). No regressions in existing specs.
- License health check (`Premature end of file` / `getJahiaLicensePackage ... null` in jahia logs): **0**.
- Verified the freshly built `2.0.3-SNAPSHOT` jar embeds `roles.xml` inside `META-INF/import.zip`.