### PR TITLE
refactor: nest GraphQL operations under a bulkCreateUsers namespace container

### DIFF
--- a/src/javascript/registrations/CreateUsers/CreateUsers.gql.js
+++ b/src/javascript/registrations/CreateUsers/CreateUsers.gql.js
@@ -2,19 +2,23 @@ import {gql} from '@apollo/client';
 
 export const GET_MAX_UPLOAD_SIZE = gql`
     query BulkCreateUsersMaxUploadSize {
-        bulkCreateUsersMaxUploadSize
+        bulkCreateUsers {
+            maxUploadSize
+        }
     }
 `;
 
 export const BULK_CREATE_USERS_IMPORT = gql`
     mutation BulkCreateUsersImport($csvContent: String!, $separator: String, $siteKey: String, $selectedColumns: [String], $overwrite: Boolean) {
-        bulkCreateUsersImport(csvContent: $csvContent, separator: $separator, siteKey: $siteKey, selectedColumns: $selectedColumns, overwrite: $overwrite) {
-            success
-            createdCount
-            updatedCount
-            skippedCount
-            errorCount
-            errors
+        bulkCreateUsers {
+            importUsers(csvContent: $csvContent, separator: $separator, siteKey: $siteKey, selectedColumns: $selectedColumns, overwrite: $overwrite) {
+                success
+                createdCount
+                updatedCount
+                skippedCount
+                errorCount
+                errors
+            }
         }
     }
 `;

--- a/src/javascript/registrations/CreateUsers/createUsers.jsx
+++ b/src/javascript/registrations/CreateUsers/createUsers.jsx
@@ -59,7 +59,7 @@ export const CreateUsers = () => {
     }, [t]);
 
     const {data: settingsData} = useQuery(GET_MAX_UPLOAD_SIZE);
-    const maxSize = settingsData?.bulkCreateUsersMaxUploadSize;
+    const maxSize = settingsData?.bulkCreateUsers?.maxUploadSize;
     const maxSizeMb = typeof maxSize === 'number' ? Math.floor(maxSize / (1024 * 1024)) : null;
 
     const [importUsers, {loading: isUploading}] = useMutation(BULK_CREATE_USERS_IMPORT);
@@ -128,7 +128,7 @@ export const CreateUsers = () => {
                     overwrite
                 }
             });
-            const result = data?.bulkCreateUsersImport;
+            const result = data?.bulkCreateUsers?.importUsers;
             setImportResult(result);
             if (result?.success) {
                 addMessage('success', t('result.success', {count: result.createdCount}));

--- a/src/main/java/org/jahia/community/bulkcreateusers/graphql/BulkCreateUsersMutation.java
+++ b/src/main/java/org/jahia/community/bulkcreateusers/graphql/BulkCreateUsersMutation.java
@@ -1,0 +1,120 @@
+package org.jahia.community.bulkcreateusers.graphql;
+
+import graphql.annotations.annotationTypes.GraphQLDescription;
+import graphql.annotations.annotationTypes.GraphQLField;
+import graphql.annotations.annotationTypes.GraphQLName;
+import graphql.annotations.annotationTypes.GraphQLNonNull;
+import org.jahia.community.bulkcreateusers.users.UsersHandler;
+import org.jahia.modules.graphql.provider.dxm.security.GraphQLRequiresPermission;
+import org.jahia.osgi.BundleUtils;
+import org.jahia.services.content.JCRNodeWrapper;
+import org.jahia.services.content.JCRSessionFactory;
+import org.jahia.services.content.JCRSessionWrapper;
+import org.jahia.settings.SettingsBean;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.jcr.PathNotFoundException;
+import javax.jcr.RepositoryException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Pattern;
+
+@GraphQLName("BulkCreateUsersMutation")
+@GraphQLDescription("Bulk Create Users mutations")
+public class BulkCreateUsersMutation {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(BulkCreateUsersMutation.class);
+
+    // Permission required to bulk-import users at the server (global) scope. This intentionally matches the
+    // fine-grained @GraphQLRequiresPermission("adminUsersBulkCreate") gate so that a role granting only
+    // adminUsersBulkCreate can perform the global import end-to-end (no broader "adminUsers" needed).
+    private static final String SERVER_USERS_PERMISSION = "adminUsersBulkCreate";
+    // Permission required to manage users within a single site (site-scope branch is unchanged).
+    private static final String SITE_USERS_PERMISSION = "siteAdminUsers";
+    // Broad server-level users-admin permission, still accepted as a fallback for the per-site scope.
+    private static final String GLOBAL_USERS_ADMIN_PERMISSION = "adminUsers";
+    // A site key is a short, opaque identifier: letters, digits, dash and underscore only. Enforcing this
+    // shape also prevents path traversal when the key is composed into the "/sites/<key>" node path below.
+    private static final Pattern SITE_KEY_PATTERN = Pattern.compile("[A-Za-z0-9_-]{1,150}");
+
+    @GraphQLField
+    @GraphQLName("importUsers")
+    @GraphQLDescription("Imports users from a CSV string; returns a detailed result with per-user counts and errors")
+    @GraphQLRequiresPermission("adminUsersBulkCreate")
+    public BulkCreateUsersResult importUsers(
+            @GraphQLName("csvContent") @GraphQLNonNull final String csvContent,
+            @GraphQLName("separator") final String separator,
+            @GraphQLName("siteKey") final String siteKey,
+            @GraphQLName("selectedColumns") final List<String> selectedColumns,
+            @GraphQLName("overwrite") final Boolean overwrite) {
+        final long maxBytes = SettingsBean.getInstance().getJahiaFileUploadMaxSize();
+        if (maxBytes > 0 && csvContent.getBytes(StandardCharsets.UTF_8).length > maxBytes) {
+            LOGGER.warn("Rejecting bulk user import: payload exceeds configured upload size limit of {} bytes", maxBytes);
+            return new BulkCreateUsersResult(false, 0, 0, 0, 1,
+                    Collections.singletonList("CSV payload exceeds the configured upload size limit"));
+        }
+        final UsersHandler handler = BundleUtils.getOsgiService(UsersHandler.class, null);
+        if (handler == null) {
+            LOGGER.error("UsersHandler service is not available");
+            return new BulkCreateUsersResult(false, 0, 0, 0, 1, Collections.singletonList("Service unavailable"));
+        }
+        final String sep = (separator != null && !separator.isEmpty()) ? separator : ",";
+        final String site = (siteKey != null && !siteKey.isEmpty()) ? siteKey : null;
+        if (site != null && !isValidSiteKey(site)) {
+            LOGGER.warn("Rejecting bulk user import: malformed siteKey");
+            return new BulkCreateUsersResult(false, 0, 0, 0, 1,
+                    Collections.singletonList("Invalid siteKey"));
+        }
+        // The @GraphQLRequiresPermission gate above is not scope-aware: it does not verify that the caller
+        // may administer the *specific* target. Re-check the permission against the resolved scope so a
+        // caller cannot pivot to a site (or to the global user base) they do not administer.
+        if (!isAuthorizedForScope(site)) {
+            LOGGER.warn("Rejecting bulk user import: caller not authorized for the requested scope");
+            return new BulkCreateUsersResult(false, 0, 0, 0, 1,
+                    Collections.singletonList("Not authorized to manage users in the requested scope"));
+        }
+        try {
+            return handler.importUsers(csvContent, sep, site, selectedColumns, Boolean.TRUE.equals(overwrite));
+        } catch (Exception e) {
+            LOGGER.error("Error during bulk user import", e);
+            return new BulkCreateUsersResult(false, 0, 0, 0, 1,
+                    Collections.singletonList("Internal error during bulk user import"));
+        }
+    }
+
+    /** True when {@code siteKey} is a well-formed, traversal-safe site identifier. Visible for testing. */
+    static boolean isValidSiteKey(String siteKey) {
+        return siteKey != null && SITE_KEY_PATTERN.matcher(siteKey).matches();
+    }
+
+    /**
+     * Verifies the authenticated caller actually holds the users-admin permission on the requested scope,
+     * evaluated through their own (ACL-respecting) session — not the system session used for the writes.
+     *
+     * <ul>
+     *   <li>{@code siteKey == null} (global users): requires {@code adminUsersBulkCreate} on the repository
+     *       root, matching the fine-grained gate so the bulk-create role works end-to-end.</li>
+     *   <li>otherwise: requires {@code siteAdminUsers} (or {@code adminUsers}) on {@code /sites/<siteKey>}.</li>
+     * </ul>
+     *
+     * Fails closed on any repository error or unknown site.
+     */
+    private static boolean isAuthorizedForScope(String siteKey) {
+        try {
+            final JCRSessionWrapper session = JCRSessionFactory.getInstance().getCurrentUserSession();
+            if (siteKey == null) {
+                return session.getNode("/").hasPermission(SERVER_USERS_PERMISSION);
+            }
+            final JCRNodeWrapper siteNode = session.getNode("/sites/" + siteKey);
+            return siteNode.hasPermission(SITE_USERS_PERMISSION) || siteNode.hasPermission(GLOBAL_USERS_ADMIN_PERMISSION);
+        } catch (PathNotFoundException e) {
+            LOGGER.warn("Authorization denied: requested site does not exist");
+            return false;
+        } catch (RepositoryException e) {
+            LOGGER.error("Authorization check failed; denying import", e);
+            return false;
+        }
+    }
+}

--- a/src/main/java/org/jahia/community/bulkcreateusers/graphql/BulkCreateUsersMutationExtension.java
+++ b/src/main/java/org/jahia/community/bulkcreateusers/graphql/BulkCreateUsersMutationExtension.java
@@ -3,124 +3,20 @@ package org.jahia.community.bulkcreateusers.graphql;
 import graphql.annotations.annotationTypes.GraphQLDescription;
 import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
-import graphql.annotations.annotationTypes.GraphQLNonNull;
 import graphql.annotations.annotationTypes.GraphQLTypeExtension;
-import org.jahia.community.bulkcreateusers.users.UsersHandler;
 import org.jahia.modules.graphql.provider.dxm.DXGraphQLProvider;
-import org.jahia.modules.graphql.provider.dxm.security.GraphQLRequiresPermission;
-import org.jahia.osgi.BundleUtils;
-import org.jahia.services.content.JCRNodeWrapper;
-import org.jahia.services.content.JCRSessionFactory;
-import org.jahia.services.content.JCRSessionWrapper;
-import org.jahia.settings.SettingsBean;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.jcr.PathNotFoundException;
-import javax.jcr.RepositoryException;
-import java.nio.charset.StandardCharsets;
-import java.util.Collections;
-import java.util.List;
-import java.util.regex.Pattern;
 
 @GraphQLTypeExtension(DXGraphQLProvider.Mutation.class)
-@GraphQLName("BulkCreateUsersMutations")
-@GraphQLDescription("Bulk create users mutations")
+@GraphQLDescription("Bulk Create Users mutations")
 public class BulkCreateUsersMutationExtension {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(BulkCreateUsersMutationExtension.class);
-
-    // Permission required to bulk-import users at the server (global) scope. This intentionally matches the
-    // fine-grained @GraphQLRequiresPermission("adminUsersBulkCreate") gate so that a role granting only
-    // adminUsersBulkCreate can perform the global import end-to-end (no broader "adminUsers" needed).
-    private static final String SERVER_USERS_PERMISSION = "adminUsersBulkCreate";
-    // Permission required to manage users within a single site (site-scope branch is unchanged).
-    private static final String SITE_USERS_PERMISSION = "siteAdminUsers";
-    // Broad server-level users-admin permission, still accepted as a fallback for the per-site scope.
-    private static final String GLOBAL_USERS_ADMIN_PERMISSION = "adminUsers";
-    // A site key is a short, opaque identifier: letters, digits, dash and underscore only. Enforcing this
-    // shape also prevents path traversal when the key is composed into the "/sites/<key>" node path below.
-    private static final Pattern SITE_KEY_PATTERN = Pattern.compile("[A-Za-z0-9_-]{1,150}");
 
     private BulkCreateUsersMutationExtension() {
     }
 
     @GraphQLField
-    @GraphQLName("bulkCreateUsersImport")
-    @GraphQLDescription("Imports users from a CSV string; returns a detailed result with per-user counts and errors")
-    @GraphQLRequiresPermission("adminUsersBulkCreate")
-    public static BulkCreateUsersResult importUsers(
-            @GraphQLName("csvContent") @GraphQLNonNull final String csvContent,
-            @GraphQLName("separator") final String separator,
-            @GraphQLName("siteKey") final String siteKey,
-            @GraphQLName("selectedColumns") final List<String> selectedColumns,
-            @GraphQLName("overwrite") final Boolean overwrite) {
-        final long maxBytes = SettingsBean.getInstance().getJahiaFileUploadMaxSize();
-        if (maxBytes > 0 && csvContent.getBytes(StandardCharsets.UTF_8).length > maxBytes) {
-            LOGGER.warn("Rejecting bulk user import: payload exceeds configured upload size limit of {} bytes", maxBytes);
-            return new BulkCreateUsersResult(false, 0, 0, 0, 1,
-                    Collections.singletonList("CSV payload exceeds the configured upload size limit"));
-        }
-        final UsersHandler handler = BundleUtils.getOsgiService(UsersHandler.class, null);
-        if (handler == null) {
-            LOGGER.error("UsersHandler service is not available");
-            return new BulkCreateUsersResult(false, 0, 0, 0, 1, Collections.singletonList("Service unavailable"));
-        }
-        final String sep = (separator != null && !separator.isEmpty()) ? separator : ",";
-        final String site = (siteKey != null && !siteKey.isEmpty()) ? siteKey : null;
-        if (site != null && !isValidSiteKey(site)) {
-            LOGGER.warn("Rejecting bulk user import: malformed siteKey");
-            return new BulkCreateUsersResult(false, 0, 0, 0, 1,
-                    Collections.singletonList("Invalid siteKey"));
-        }
-        // The @GraphQLRequiresPermission gate above is not scope-aware: it does not verify that the caller
-        // may administer the *specific* target. Re-check the permission against the resolved scope so a
-        // caller cannot pivot to a site (or to the global user base) they do not administer.
-        if (!isAuthorizedForScope(site)) {
-            LOGGER.warn("Rejecting bulk user import: caller not authorized for the requested scope");
-            return new BulkCreateUsersResult(false, 0, 0, 0, 1,
-                    Collections.singletonList("Not authorized to manage users in the requested scope"));
-        }
-        try {
-            return handler.importUsers(csvContent, sep, site, selectedColumns, Boolean.TRUE.equals(overwrite));
-        } catch (Exception e) {
-            LOGGER.error("Error during bulk user import", e);
-            return new BulkCreateUsersResult(false, 0, 0, 0, 1,
-                    Collections.singletonList("Internal error during bulk user import"));
-        }
-    }
-
-    /** True when {@code siteKey} is a well-formed, traversal-safe site identifier. Visible for testing. */
-    static boolean isValidSiteKey(String siteKey) {
-        return siteKey != null && SITE_KEY_PATTERN.matcher(siteKey).matches();
-    }
-
-    /**
-     * Verifies the authenticated caller actually holds the users-admin permission on the requested scope,
-     * evaluated through their own (ACL-respecting) session — not the system session used for the writes.
-     *
-     * <ul>
-     *   <li>{@code siteKey == null} (global users): requires {@code adminUsersBulkCreate} on the repository
-     *       root, matching the fine-grained gate so the bulk-create role works end-to-end.</li>
-     *   <li>otherwise: requires {@code siteAdminUsers} (or {@code adminUsers}) on {@code /sites/<siteKey>}.</li>
-     * </ul>
-     *
-     * Fails closed on any repository error or unknown site.
-     */
-    private static boolean isAuthorizedForScope(String siteKey) {
-        try {
-            final JCRSessionWrapper session = JCRSessionFactory.getInstance().getCurrentUserSession();
-            if (siteKey == null) {
-                return session.getNode("/").hasPermission(SERVER_USERS_PERMISSION);
-            }
-            final JCRNodeWrapper siteNode = session.getNode("/sites/" + siteKey);
-            return siteNode.hasPermission(SITE_USERS_PERMISSION) || siteNode.hasPermission(GLOBAL_USERS_ADMIN_PERMISSION);
-        } catch (PathNotFoundException e) {
-            LOGGER.warn("Authorization denied: requested site does not exist");
-            return false;
-        } catch (RepositoryException e) {
-            LOGGER.error("Authorization check failed; denying import", e);
-            return false;
-        }
+    @GraphQLName("bulkCreateUsers")
+    @GraphQLDescription("Bulk Create Users mutation namespace")
+    public static BulkCreateUsersMutation bulkCreateUsers() {
+        return new BulkCreateUsersMutation();
     }
 }

--- a/src/main/java/org/jahia/community/bulkcreateusers/graphql/BulkCreateUsersQuery.java
+++ b/src/main/java/org/jahia/community/bulkcreateusers/graphql/BulkCreateUsersQuery.java
@@ -1,0 +1,20 @@
+package org.jahia.community.bulkcreateusers.graphql;
+
+import graphql.annotations.annotationTypes.GraphQLDescription;
+import graphql.annotations.annotationTypes.GraphQLField;
+import graphql.annotations.annotationTypes.GraphQLName;
+import org.jahia.modules.graphql.provider.dxm.security.GraphQLRequiresPermission;
+import org.jahia.settings.SettingsBean;
+
+@GraphQLName("BulkCreateUsersQuery")
+@GraphQLDescription("Bulk Create Users queries")
+public class BulkCreateUsersQuery {
+
+    @GraphQLField
+    @GraphQLName("maxUploadSize")
+    @GraphQLDescription("Maximum allowed CSV upload size in bytes, as configured in Jahia settings")
+    @GraphQLRequiresPermission("adminUsersBulkCreate")
+    public Long maxUploadSize() {
+        return SettingsBean.getInstance().getJahiaFileUploadMaxSize();
+    }
+}

--- a/src/main/java/org/jahia/community/bulkcreateusers/graphql/BulkCreateUsersQueryExtension.java
+++ b/src/main/java/org/jahia/community/bulkcreateusers/graphql/BulkCreateUsersQueryExtension.java
@@ -5,22 +5,18 @@ import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
 import graphql.annotations.annotationTypes.GraphQLTypeExtension;
 import org.jahia.modules.graphql.provider.dxm.DXGraphQLProvider;
-import org.jahia.modules.graphql.provider.dxm.security.GraphQLRequiresPermission;
-import org.jahia.settings.SettingsBean;
 
 @GraphQLTypeExtension(DXGraphQLProvider.Query.class)
-@GraphQLName("BulkCreateUsersQueries")
-@GraphQLDescription("Bulk create users queries")
+@GraphQLDescription("Bulk Create Users queries")
 public class BulkCreateUsersQueryExtension {
 
     private BulkCreateUsersQueryExtension() {
     }
 
     @GraphQLField
-    @GraphQLName("bulkCreateUsersMaxUploadSize")
-    @GraphQLDescription("Maximum allowed CSV upload size in bytes, as configured in Jahia settings")
-    @GraphQLRequiresPermission("adminUsersBulkCreate")
-    public static Long maxUploadSize() {
-        return SettingsBean.getInstance().getJahiaFileUploadMaxSize();
+    @GraphQLName("bulkCreateUsers")
+    @GraphQLDescription("Bulk Create Users query namespace")
+    public static BulkCreateUsersQuery bulkCreateUsers() {
+        return new BulkCreateUsersQuery();
     }
 }

--- a/src/test/java/org/jahia/community/bulkcreateusers/graphql/BulkCreateUsersMutationExtensionTest.java
+++ b/src/test/java/org/jahia/community/bulkcreateusers/graphql/BulkCreateUsersMutationExtensionTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Unit tests for {@link BulkCreateUsersMutationExtension#isValidSiteKey(String)} — the traversal-safe
+ * Unit tests for {@link BulkCreateUsersMutation#isValidSiteKey(String)} — the traversal-safe
  * site-key guard. A malformed key here would be composed into the "/sites/&lt;key&gt;" node path used by
  * the scope authorization check, so rejecting path tokens is security-relevant.
  */
@@ -18,7 +18,7 @@ class BulkCreateUsersMutationExtensionTest {
     @ValueSource(strings = {"digitall", "my-site", "site_01", "ACME", "a"})
     @DisplayName("accepts well-formed site keys")
     void acceptsValidKeys(String key) {
-        assertThat(BulkCreateUsersMutationExtension.isValidSiteKey(key)).isTrue();
+        assertThat(BulkCreateUsersMutation.isValidSiteKey(key)).isTrue();
     }
 
     @ParameterizedTest
@@ -28,14 +28,14 @@ class BulkCreateUsersMutationExtensionTest {
     })
     @DisplayName("rejects keys containing path, whitespace, or special characters")
     void rejectsTraversalAndSpecials(String key) {
-        assertThat(BulkCreateUsersMutationExtension.isValidSiteKey(key)).isFalse();
+        assertThat(BulkCreateUsersMutation.isValidSiteKey(key)).isFalse();
     }
 
     @Test
     @DisplayName("rejects null and empty")
     void rejectsNullAndEmpty() {
-        assertThat(BulkCreateUsersMutationExtension.isValidSiteKey(null)).isFalse();
-        assertThat(BulkCreateUsersMutationExtension.isValidSiteKey("")).isFalse();
+        assertThat(BulkCreateUsersMutation.isValidSiteKey(null)).isFalse();
+        assertThat(BulkCreateUsersMutation.isValidSiteKey("")).isFalse();
     }
 
     @Test
@@ -45,6 +45,6 @@ class BulkCreateUsersMutationExtensionTest {
         for (int i = 0; i < 151; i++) {
             sb.append('a');
         }
-        assertThat(BulkCreateUsersMutationExtension.isValidSiteKey(sb.toString())).isFalse();
+        assertThat(BulkCreateUsersMutation.isValidSiteKey(sb.toString())).isFalse();
     }
 }

--- a/tests/cypress/e2e/01-bulkCreateUsers-API.cy.ts
+++ b/tests/cypress/e2e/01-bulkCreateUsers-API.cy.ts
@@ -34,7 +34,7 @@ describe('Bulk Create Users', () => {
                 mutation: importUsers,
                 variables: {csvContent: CSV_VALID, separator: ',', selectedColumns: REQUIRED_COLUMNS}
             })
-                .its('data.bulkCreateUsersImport')
+                .its('data.bulkCreateUsers.importUsers')
                 .should(result => {
                     expect(result.success).to.be.true;
                     expect(result.createdCount).to.eq(2);
@@ -49,7 +49,7 @@ describe('Bulk Create Users', () => {
                 mutation: importUsers,
                 variables: {csvContent: CSV_VALID, separator: ',', selectedColumns: REQUIRED_COLUMNS}
             })
-                .its('data.bulkCreateUsersImport')
+                .its('data.bulkCreateUsers.importUsers')
                 .should(result => {
                     expect(result).to.have.all.keys('__typename', 'success', 'createdCount', 'updatedCount', 'skippedCount', 'errorCount', 'errors');
                 });
@@ -60,7 +60,7 @@ describe('Bulk Create Users', () => {
                 mutation: importUsers,
                 variables: {csvContent: CSV_VALID, separator: ',', selectedColumns: REQUIRED_COLUMNS}
             })
-                .its('data.bulkCreateUsersImport')
+                .its('data.bulkCreateUsers.importUsers')
                 .should(result => {
                     expect(result.skippedCount).to.be.greaterThan(0);
                     expect(result.createdCount).to.eq(0);
@@ -77,7 +77,7 @@ describe('Bulk Create Users', () => {
                     selectedColumns: [...REQUIRED_COLUMNS, 'j:email']
                 }
             })
-                .its('data.bulkCreateUsersImport')
+                .its('data.bulkCreateUsers.importUsers')
                 .should(result => {
                     expect(result.success).to.be.true;
                     expect(result.createdCount).to.eq(2);
@@ -94,7 +94,7 @@ describe('Bulk Create Users', () => {
                     selectedColumns: REQUIRED_COLUMNS  // j:email NOT selected
                 }
             })
-                .its('data.bulkCreateUsersImport')
+                .its('data.bulkCreateUsers.importUsers')
                 .should(result => {
                     expect(result.success).to.be.true;
                 });
@@ -106,7 +106,7 @@ describe('Bulk Create Users', () => {
                 mutation: importUsers,
                 variables: {csvContent: csvMissingColumns, separator: ',', selectedColumns: REQUIRED_COLUMNS}
             })
-                .its('data.bulkCreateUsersImport')
+                .its('data.bulkCreateUsers.importUsers')
                 .should(result => {
                     expect(result.success).to.be.false;
                     expect(result.errorCount).to.be.greaterThan(0);
@@ -118,7 +118,7 @@ describe('Bulk Create Users', () => {
                 mutation: importUsers,
                 variables: {csvContent: '', separator: ',', selectedColumns: REQUIRED_COLUMNS}
             })
-                .its('data.bulkCreateUsersImport')
+                .its('data.bulkCreateUsers.importUsers')
                 .should(result => {
                     expect(result.success).to.be.false;
                 });
@@ -131,7 +131,7 @@ describe('Bulk Create Users', () => {
                 mutation: importUsers,
                 variables: {csvContent: semicolonCsv, separator: ';', selectedColumns: REQUIRED_COLUMNS}
             })
-                .its('data.bulkCreateUsersImport')
+                .its('data.bulkCreateUsers.importUsers')
                 .should(result => {
                     expect(result.success).to.be.true;
                     expect(result.createdCount).to.eq(1);
@@ -146,7 +146,7 @@ describe('Bulk Create Users', () => {
                 mutation: importUsers,
                 variables: {csvContent: csvWithGroups, separator: ',', selectedColumns: REQUIRED_COLUMNS}
             })
-                .its('data.bulkCreateUsersImport')
+                .its('data.bulkCreateUsers.importUsers')
                 .should(result => {
                     expect(result.success).to.be.true;
                     expect(result.createdCount).to.eq(1);
@@ -160,7 +160,7 @@ describe('Bulk Create Users', () => {
                 mutation: importUsers,
                 variables: {csvContent: csvWithBadGroup, separator: ',', selectedColumns: REQUIRED_COLUMNS}
             })
-                .its('data.bulkCreateUsersImport')
+                .its('data.bulkCreateUsers.importUsers')
                 .should(result => {
                     // user is created even though the group was not found
                     expect(result.success).to.be.true;
@@ -175,7 +175,7 @@ describe('Bulk Create Users', () => {
                 mutation: importUsers,
                 variables: {csvContent: csvUpdated, separator: ',', selectedColumns: REQUIRED_COLUMNS, overwrite: true}
             })
-                .its('data.bulkCreateUsersImport')
+                .its('data.bulkCreateUsers.importUsers')
                 .should(result => {
                     expect(result.success).to.be.true;
                     expect(result.updatedCount).to.eq(1);
@@ -193,7 +193,7 @@ describe('Bulk Create Users', () => {
                 mutation: importUsers,
                 variables: {csvContent: CSV_WITH_EMAIL, separator: ','}
             })
-                .its('data.bulkCreateUsersImport')
+                .its('data.bulkCreateUsers.importUsers')
                 .should(result => {
                     expect(result.success).to.be.true;
                     expect(result.createdCount).to.eq(2);
@@ -207,7 +207,7 @@ describe('Bulk Create Users', () => {
                 mutation: importUsers,
                 variables: {csvContent: CSV_WITH_EMAIL, separator: ',', selectedColumns: []}
             })
-                .its('data.bulkCreateUsersImport')
+                .its('data.bulkCreateUsers.importUsers')
                 .should(result => {
                     expect(result.success).to.be.true;
                     expect(result.createdCount).to.eq(2);
@@ -225,7 +225,7 @@ describe('Bulk Create Users', () => {
                 mutation: importUsers,
                 variables: {csvContent: csvWithBadRow, separator: ',', selectedColumns: REQUIRED_COLUMNS}
             })
-                .its('data.bulkCreateUsersImport')
+                .its('data.bulkCreateUsers.importUsers')
                 .should(result => {
                     expect(result.createdCount).to.eq(2);
                     expect(result.errorCount).to.be.greaterThan(0);
@@ -239,7 +239,7 @@ describe('Bulk Create Users', () => {
                 mutation: importUsers,
                 variables: {csvContent: csvWithRoot, separator: ',', selectedColumns: REQUIRED_COLUMNS, overwrite: true}
             })
-                .its('data.bulkCreateUsersImport')
+                .its('data.bulkCreateUsers.importUsers')
                 .should(result => {
                     expect(result.updatedCount).to.eq(0);
                     expect(result.skippedCount).to.eq(1);

--- a/tests/cypress/e2e/05-bulkCreateUsers-Permissions.cy.ts
+++ b/tests/cypress/e2e/05-bulkCreateUsers-Permissions.cy.ts
@@ -90,9 +90,9 @@ describe('Bulk Create Users — permission enforcement', () => {
             // adminUsersBulkCreate) and the import actually creates the user.
             importUsersAs(ALLOWED_USER).then((result: never) => {
                 expect(errorsOf(result), 'should have no GraphQL errors').to.have.length(0);
-                const imported = (result as {data: {bulkCreateUsersImport: {
+                const imported = (result as {data: {bulkCreateUsers: {importUsers: {
                     success: boolean; createdCount: number; errorCount: number; errors: string[];
-                }}}).data.bulkCreateUsersImport;
+                }}}}).data.bulkCreateUsers.importUsers;
                 expect(imported.success, 'import success').to.be.true;
                 expect(imported.createdCount, 'createdCount').to.eq(1);
                 expect(imported.errorCount, 'errorCount').to.eq(0);

--- a/tests/cypress/fixtures/graphql/mutation/importUsers.graphql
+++ b/tests/cypress/fixtures/graphql/mutation/importUsers.graphql
@@ -1,10 +1,12 @@
 mutation BulkCreateUsersImport($csvContent: String!, $separator: String, $siteKey: String, $selectedColumns: [String], $overwrite: Boolean) {
-    bulkCreateUsersImport(csvContent: $csvContent, separator: $separator, siteKey: $siteKey, selectedColumns: $selectedColumns, overwrite: $overwrite) {
-        success
-        createdCount
-        updatedCount
-        skippedCount
-        errorCount
-        errors
+    bulkCreateUsers {
+        importUsers(csvContent: $csvContent, separator: $separator, siteKey: $siteKey, selectedColumns: $selectedColumns, overwrite: $overwrite) {
+            success
+            createdCount
+            updatedCount
+            skippedCount
+            errorCount
+            errors
+        }
     }
 }

--- a/tests/cypress/fixtures/graphql/query/maxUploadSize.graphql
+++ b/tests/cypress/fixtures/graphql/query/maxUploadSize.graphql
@@ -1,3 +1,5 @@
 query BulkCreateUsersMaxUploadSize {
-    bulkCreateUsersMaxUploadSize
+    bulkCreateUsers {
+        maxUploadSize
+    }
 }


### PR DESCRIPTION
## What & why
Brings the module in line with the Jahia GraphQL convention: group operations under **one hierarchical namespace container** instead of flat, prefix-named root fields.

### Schema change (breaking)
```graphql
# before: query { bulkCreateUsersMaxUploadSize }   mutation { bulkCreateUsersImport(...) }
# after:  query { bulkCreateUsers { maxUploadSize } }  mutation { bulkCreateUsers { importUsers(...) } }
```

### How
- New holder types `BulkCreateUsersQuery` / `BulkCreateUsersMutation` hold the operations as instance `@GraphQLField` methods (`maxUploadSize`, `importUsers`); `BulkCreateUsersResult` return type stays a separate file.
- The `*Extension` classes keep a single `bulkCreateUsers` accessor field.
- `@GraphQLRequiresPermission` stays on each leaf — authorization unchanged.
- (`importUsers` chosen as the leaf name over bare `import` to avoid a JS reserved word in the frontend.)
- Unit test repointed to the holder; frontend (`*.gql.js`/`.jsx`) and Cypress fixtures/specs updated in lockstep.

## Verification
- `mvn clean install` (JDK17): **BUILD SUCCESS**, 84 JUnit tests pass, webpack OK
- Cypress E2E: **44/44 pass** (API, UI ×3, permission)
- SonarQube quality gate: **OK** (0 new issues, 0 duplication)