### PR TITLE
ci: add GitHub Actions workflows (nightly, on-PR, on-merge)

### DIFF
--- a/.github/workflows/nightly-sn.yml
+++ b/.github/workflows/nightly-sn.yml
@@ -1,0 +1,21 @@
+name: Nightly Test run (Jahia Snapshot)
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron:  '0 3 * * *'
+
+jobs:
+  integration-tests-sn:
+    name: Integration Tests (Jahia SN)
+    secrets: inherit
+    uses: Jahia/jahia-modules-action/.github/workflows/reusable-integration-tests.yml@v2
+    with:
+      module_id: bulk-create-users
+      module_branch: main
+      jahia_image: ghcr.io/jahia/jahia-ee-dev:8-SNAPSHOT
+      provisioning_manifest: provisioning-manifest-snapshot.yml
+      incident_service: bulk-create-users-JahiaSN
+      testrail_project: Bulk Create Users Module
+      artifact_prefix: bcu-nightly-sn
+      timeout_job: 45

--- a/.github/workflows/on-code-change.yml
+++ b/.github/workflows/on-code-change.yml
@@ -1,0 +1,74 @@
+# This workflow is triggered every time a change is pushed to any branches
+# Github actions command reference: https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions
+name: On Code Change (PR)
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  update-signature:
+    name: Update module signature
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jahia/jahia-modules-action/update-signature@v2
+        with:
+          nexus_username: ${{ secrets.NEXUS_USERNAME }}
+          nexus_password: ${{ secrets.NEXUS_PASSWORD }}
+          nexus_enterprise_releases_url: ${{ secrets.NEXUS_ENTERPRISE_RELEASES_URL }}
+
+  static-analysis:
+    name: Static Analysis (linting, vulns)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Jahia/jahia-modules-action/static-analysis@v2
+        with:
+          node_version: 20
+          auditci_level: critical
+
+  build:
+    name: Build Module
+    needs: update-signature
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/jahia/jahia-docker-mvn-cache:11-jdk-noble-mvn-loaded
+      credentials:
+        username: ${{ secrets.GH_PACKAGES_USERNAME }}
+        password: ${{ secrets.GH_PACKAGES_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jahia/jahia-modules-action/build@v2
+        with:
+          nexus_username: ${{ secrets.NEXUS_USERNAME }}
+          nexus_password: ${{ secrets.NEXUS_PASSWORD }}
+
+  sonar-analysis:
+    name: Sonar Analysis
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jahia/jahia-modules-action/sonar-analysis@v2
+        with:
+          primary_release_branch: main
+          github_pr_id: ${{github.event.number}}
+          sonar_url: ${{ secrets.SONAR_URL }}
+          sonar_token: ${{ secrets.SONAR_TOKEN }}
+
+  integration-tests:
+    name: Integration Tests
+    secrets: inherit
+    needs: build
+    uses: Jahia/jahia-modules-action/.github/workflows/reusable-integration-tests.yml@v2
+    with:
+      module_id: bulk-create-users
+      module_branch: ${{ github.ref }}
+      jahia_image: ghcr.io/jahia/jahia-ee-dev:8-SNAPSHOT
+      provisioning_manifest: provisioning-manifest-build.yml
+      testrail_project: Bulk Create Users Module
+      should_skip_testrail: true
+      should_use_build_artifacts: true
+      artifact_prefix: bcu
+      timeout_job: 45

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -1,0 +1,83 @@
+# This workflow is triggered every time a change is pushed to any branches
+# Github actions command reference: https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions
+name: On merge to main
+
+on:
+  push:
+    branches:
+      - 'main'
+    tags-ignore:
+      - '**'
+
+jobs:
+  update-signature:
+    name: Update module signature
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jahia/jahia-modules-action/update-signature@v2
+        with:
+          nexus_username: ${{ secrets.NEXUS_USERNAME }}
+          nexus_password: ${{ secrets.NEXUS_PASSWORD }}
+
+  build:
+    name: Build Module
+    needs: update-signature
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/jahia/jahia-docker-mvn-cache:11-jdk-noble-mvn-loaded
+      credentials:
+        username: ${{ secrets.GH_PACKAGES_USERNAME }}
+        password: ${{ secrets.GH_PACKAGES_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jahia/jahia-modules-action/build@v2
+        with:
+          nexus_username: ${{ secrets.NEXUS_USERNAME }}
+          nexus_password: ${{ secrets.NEXUS_PASSWORD }}
+
+  sbom:
+    name: SBOM processing
+    needs: build
+    runs-on: ubuntu-latest
+    container:
+      image: cyclonedx/cyclonedx-cli:0.24.2
+    steps:
+      - uses: jahia/jahia-modules-action/sbom-processing@v2
+        with:
+          dependencytrack_hostname: ${{ vars.DEPENDENCYTRACK_HOSTNAME }}
+          dependencytrack_apikey: ${{ secrets.DEPENDENCYTRACK_APIKEY }}
+          sbom_artifacts: 'build-artifacts'
+
+  publish:
+    name: Publish module
+    needs: build
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/jahia/jahia-docker-mvn-cache:11-jdk-noble-mvn-loaded
+      credentials:
+        username: ${{ secrets.GH_PACKAGES_USERNAME }}
+        password: ${{ secrets.GH_PACKAGES_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jahia/jahia-modules-action/publish@v2
+        with:
+          nexus_username: ${{ secrets.NEXUS_USERNAME }}
+          nexus_password: ${{ secrets.NEXUS_PASSWORD }}
+
+  integration-tests:
+    name: Integration Tests
+    secrets: inherit
+    needs: build
+    uses: Jahia/jahia-modules-action/.github/workflows/reusable-integration-tests.yml@v2
+    with:
+      module_id: bulk-create-users
+      module_branch: main
+      jahia_image: ghcr.io/jahia/jahia-ee-dev:8-SNAPSHOT
+      provisioning_manifest: provisioning-manifest-build.yml
+      incident_service: bulk-create-users-JahiaSN
+      testrail_project: Bulk Create Users Module
+      should_use_build_artifacts: true
+      artifact_prefix: bcu
+      timeout_job: 45


### PR DESCRIPTION
## What

`Jahia/bulk-create-users` had **zero** GitHub Actions workflows (only `.github/dependabot.yml`) despite already having the full CI scaffolding (`tests/ci.build.sh`, `ci.startup.sh`, `ci.postrun.sh`, `docker-compose.yml`, provisioning manifests) — just never wired to a trigger. Adds three, adapted from `Jahia/serverSettings`'s working CI (same `pom.xml` + `package.json` module shape):

- **`nightly-sn.yml`** — nightly integration-test run against Jahia Snapshot (`workflow_dispatch` + `0 3 * * *` cron).
- **`on-code-change.yml`** — runs on every PR opened/reopened/synchronized: update module signature, static analysis (lint + `auditci`), build, Sonar analysis, integration tests against build artifacts.
- **`on-merge.yml`** — runs on merge to `main`: update signature, build, SBOM processing, publish, integration tests.

Split out from #26 (the test-content PR) per request, so CI and test changes review independently.

## Please verify before merging

- `incident_service: bulk-create-users-JahiaSN` and `testrail_project: Bulk Create Users Module` follow the naming convention observed on other repos' workflows (`<module>-JahiaSN` / "Jahia X Module"), but aren't verified against real PagerDuty/TestRail entries.
- `sonar-analysis` and `sbom-processing` (SBOM/Dependency-Track) assume infrastructure that may not be provisioned for this repo yet — confirm a Sonar project and Dependency-Track config exist, or drop those jobs if not applicable.
- All three workflows use the shared `Jahia/jahia-modules-action@v2` composite actions, same as `serverSettings` — no bespoke logic introduced here.